### PR TITLE
Add HITL dossier confirmation backend integration

### DIFF
--- a/agents/human_in_loop_agent.py
+++ b/agents/human_in_loop_agent.py
@@ -1,4 +1,28 @@
+import inspect
+import logging
+from typing import Any, Dict, Optional
+
+
+logger = logging.getLogger(__name__)
+
+
 class HumanInLoopAgent:
+    def __init__(self, communication_backend: Optional[Any] = None) -> None:
+        """Create the HITL agent.
+
+        Parameters
+        ----------
+        communication_backend:
+            A concrete communication client (e.g. ``EmailAgent`` or a Slack
+            integration) responsible for contacting the event organiser.  The
+            backend is expected to expose either a ``request_confirmation`` or
+            ``send_confirmation_request`` method.  When no backend is supplied
+            the agent falls back to a deterministic simulation which keeps the
+            previous behaviour used in tests and demos.
+        """
+
+        self.communication_backend = communication_backend
+
     def request_info(self, event, extracted):
         """
         Notes:
@@ -21,3 +45,139 @@ class HumanInLoopAgent:
         )
         extracted["is_complete"] = True
         return extracted
+
+    def request_dossier_confirmation(self, event: Dict[str, Any], info: Dict[str, Any]) -> Dict[str, Any]:
+        """Ask the organiser whether a dossier should be created for the event.
+
+        The method orchestrates the interaction with the configured
+        communication backend and always returns a normalised dictionary that
+        the workflow can rely on.  The dictionary contains a boolean flag under
+        ``dossier_required`` and a ``details`` payload with contextual
+        information (contact details, rendered message, and any backend
+        response).
+        """
+
+        contact = self._extract_organizer_contact(event)
+        subject = self._build_subject(event)
+        message = self._build_message(event, info)
+        payload = {"event": event, "info": info}
+
+        backend_response: Optional[Any] = None
+        handler = self._resolve_backend_handler()
+        if handler:
+            logger.debug(
+                "Sending dossier confirmation request via backend %s", handler
+            )
+            backend_response = self._call_backend_handler(
+                handler,
+                contact=contact,
+                subject=subject,
+                message=message,
+                event=event,
+                info=info,
+                payload=payload,
+            )
+        else:
+            logger.debug(
+                "No communication backend configured; using simulated response."
+            )
+            backend_response = self._simulate_confirmation(contact, payload)
+
+        normalized = self._normalize_response(backend_response)
+        details = normalized.get("details", {})
+        if not isinstance(details, dict):
+            details = {"raw_response": details}
+        details.setdefault("contact", contact)
+        details.setdefault("subject", subject)
+        details.setdefault("message", message)
+        normalized["details"] = details
+        return normalized
+
+    def _resolve_backend_handler(self) -> Optional[Any]:
+        if not self.communication_backend:
+            return None
+
+        for attr in ("request_confirmation", "send_confirmation_request"):
+            if hasattr(self.communication_backend, attr):
+                return getattr(self.communication_backend, attr)
+        return None
+
+    def _call_backend_handler(self, handler: Any, **kwargs: Any) -> Any:
+        signature = inspect.signature(handler)
+        if any(
+            parameter.kind == inspect.Parameter.VAR_KEYWORD
+            for parameter in signature.parameters.values()
+        ):
+            return handler(**kwargs)
+
+        supported_kwargs = {
+            name: value for name, value in kwargs.items() if name in signature.parameters
+        }
+        return handler(**supported_kwargs)
+
+    def _extract_organizer_contact(self, event: Dict[str, Any]) -> Dict[str, Any]:
+        organizer = event.get("organizer") or {}
+        creator = event.get("creator") or {}
+        email = organizer.get("email") or event.get("organizer_email") or creator.get("email")
+        name = (
+            organizer.get("displayName")
+            or organizer.get("name")
+            or creator.get("displayName")
+            or creator.get("name")
+        )
+        phone = organizer.get("phone") or organizer.get("phoneNumber")
+        return {"email": email, "name": name, "phone": phone, "raw": organizer or None}
+
+    def _build_subject(self, event: Dict[str, Any]) -> str:
+        summary = event.get("summary") or "event"
+        return f"Dossier confirmation required for {summary}"
+
+    def _build_message(self, event: Dict[str, Any], info: Dict[str, Any]) -> str:
+        summary = event.get("summary", "Unknown event")
+        event_id = event.get("id", "<unknown>")
+        lines = [
+            f"Event: {summary} ({event_id})",
+            "We extracted the following information:",
+        ]
+        for key, value in info.items():
+            lines.append(f"- {key}: {value}")
+        lines.append("")
+        lines.append("Should we prepare a dossier for this event? Reply yes or no.")
+        return "\n".join(lines)
+
+    def _simulate_confirmation(self, contact: Dict[str, Any], payload: Dict[str, Any]) -> Dict[str, Any]:
+        logger.info(
+            "Simulating dossier confirmation for organiser %s", contact.get("email")
+        )
+        return {
+            "dossier_required": True,
+            "details": {
+                "simulation": True,
+                "reason": "Default simulated approval",
+                "contact": contact,
+            },
+        }
+
+    def _normalize_response(self, response: Any) -> Dict[str, Any]:
+        if isinstance(response, dict):
+            dossier_required = response.get("dossier_required")
+            if dossier_required is None:
+                dossier_required = bool(response)
+            details = response.get("details")
+            if isinstance(details, dict):
+                details = dict(details)
+            elif details is None:
+                details = {
+                    key: value for key, value in response.items() if key != "dossier_required"
+                }
+            else:
+                details = {"raw_response": details}
+            return {
+                "dossier_required": bool(dossier_required),
+                "details": details,
+            }
+
+        return {
+            "dossier_required": bool(response),
+            "details": {"raw_response": response},
+        }

--- a/agents/workflow_orchestrator.py
+++ b/agents/workflow_orchestrator.py
@@ -13,9 +13,9 @@ logger = logging.getLogger("WorkflowOrchestrator")
 
 
 class WorkflowOrchestrator:
-    def __init__(self):
+    def __init__(self, communication_backend=None):
         # Initialize the logic agent
-        self.master_agent = MasterWorkflowAgent()
+        self.master_agent = MasterWorkflowAgent(communication_backend=communication_backend)
         self.log_filename = self.master_agent.log_filename
 
     def run(self):

--- a/tests/test_master_workflow_agent_hitl.py
+++ b/tests/test_master_workflow_agent_hitl.py
@@ -1,0 +1,115 @@
+from typing import Any, Dict, Iterable, List
+
+from agents.master_workflow_agent import MasterWorkflowAgent
+
+
+class DummyBackend:
+    def __init__(self, response: Dict[str, Any]):
+        self.response = response
+        self.requests: List[Dict[str, Any]] = []
+
+    def request_confirmation(
+        self,
+        contact: Dict[str, Any],
+        subject: str,
+        message: str,
+        event: Dict[str, Any],
+        info: Dict[str, Any],
+        payload: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        self.requests.append(
+            {
+                "contact": contact,
+                "subject": subject,
+                "message": message,
+                "event": event,
+                "info": info,
+                "payload": payload,
+            }
+        )
+        return self.response
+
+
+class DummyEventAgent:
+    def __init__(self, events: Iterable[Dict[str, Any]]):
+        self._events = list(events)
+
+    def poll(self) -> Iterable[Dict[str, Any]]:
+        for event in self._events:
+            yield event
+
+
+class DummyTriggerAgent:
+    def __init__(self, result: Dict[str, Any]):
+        self._result = result
+
+    def check(self, _event: Dict[str, Any]) -> Dict[str, Any]:
+        return self._result
+
+
+class DummyExtractionAgent:
+    def __init__(self, response: Dict[str, Any]):
+        self._response = response
+
+    def extract(self, _event: Dict[str, Any]) -> Dict[str, Any]:
+        return self._response
+
+
+def _prepare_agent(backend: DummyBackend) -> MasterWorkflowAgent:
+    event = {
+        "id": "event-123",
+        "summary": "Soft trigger meeting",
+        "organizer": {"email": "organizer@example.com", "displayName": "Org"},
+    }
+    info = {"company_name": "Example Corp", "web_domain": "example.com"}
+
+    agent = MasterWorkflowAgent(
+        communication_backend=backend,
+        event_agent=DummyEventAgent([event]),
+        trigger_agent=DummyTriggerAgent(
+            {
+                "trigger": True,
+                "type": "soft",
+                "matched_word": "briefing",
+                "matched_field": "summary",
+            }
+        ),
+        extraction_agent=DummyExtractionAgent({"info": info, "is_complete": True}),
+    )
+    agent._send_calls: List[Dict[str, Any]] = []
+
+    def _capture_send(to_event: Dict[str, Any], event_info: Dict[str, Any]) -> None:
+        agent._send_calls.append({"event": to_event, "info": event_info})
+
+    agent._send_to_crm_agent = _capture_send  # type: ignore[assignment]
+    return agent
+
+
+def test_soft_trigger_dossier_request_accepted() -> None:
+    backend = DummyBackend(
+        {"dossier_required": True, "details": {"note": "Yes, please prepare it."}}
+    )
+    agent = _prepare_agent(backend)
+
+    agent.process_all_events()
+
+    assert len(agent._send_calls) == 1
+    assert agent._send_calls[0]["info"]["company_name"] == "Example Corp"
+
+    assert backend.requests, "Backend should have been invoked"
+    first_request = backend.requests[0]
+    assert first_request["contact"]["email"] == "organizer@example.com"
+    assert "Soft trigger meeting" in first_request["subject"]
+
+
+def test_soft_trigger_dossier_request_declined() -> None:
+    backend = DummyBackend(
+        {"dossier_required": False, "details": {"note": "No dossier required."}}
+    )
+    agent = _prepare_agent(backend)
+
+    agent.process_all_events()
+
+    assert agent._send_calls == []
+    assert len(backend.requests) == 1
+    assert backend.requests[0]["info"]["company_name"] == "Example Corp"


### PR DESCRIPTION
## Summary
- allow `HumanInLoopAgent` to receive a communication backend, drive organiser outreach, and normalise dossier confirmation responses
- update `MasterWorkflowAgent`/`WorkflowOrchestrator` to inject the backend, surface organiser feedback, and make the workflow easier to test via dependency injection
- add regression tests covering organiser approval and decline HITL paths for soft-trigger events

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d5b9ca5f70832baac1c26b8774b4de