### PR TITLE
Fix README tables for better readability

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -9,14 +9,14 @@ environments.
 
 | File | Responsibility |
 |------|----------------|
-| [`email_agent.py`](email_agent.py) | Sends transactional emails via SMTP using plain text and optional HTML bodies. Provides basic logging around delivery success/failure. |
-| [`event_polling_agent.py`](event_polling_agent.py) | Connects to Google Calendar and Google Contacts to poll upcoming events and related organiser data while filtering out noise such as birthday reminders. |
-| [`extraction_agent.py`](extraction_agent.py) | Extracts core metadata (company name, web domain) from events and flags whether the information set is complete. Designed to be extended with richer parsing. |
-| [`human_in_loop_agent.py`](human_in_loop_agent.py) | Facilitates human-in-the-loop interactions for gathering missing event data and confirming dossier creation. Works with a pluggable communication backend or a built-in simulator. |
-| [`master_workflow_agent.py`](master_workflow_agent.py) | Implements the end-to-end business logic: polls events, detects triggers, performs extraction, coordinates with humans, and hands confirmed events to downstream systems. |
-| [`s3_storage_agent.py`](s3_storage_agent.py) | Uploads files (typically generated logs) to Amazon S3 using the configured credentials. |
-| [`trigger_detection_agent.py`](trigger_detection_agent.py) | Detects hard and soft trigger phrases in event summaries/descriptions using normalised keyword matching. |
-| [`workflow_orchestrator.py`](workflow_orchestrator.py) | High-level orchestrator that initialises the `MasterWorkflowAgent`, handles error resilience, and finalises runs (e.g., optional S3 log upload). |
+| [`email_agent.py`](email_agent.py) | Sends transactional emails via SMTP using plain text and optional HTML bodies while logging delivery success or failure. |
+| [`event_polling_agent.py`](event_polling_agent.py) | Connects to Google Calendar and Google Contacts to poll upcoming events, related organiser data, and filters out noise such as birthday reminders. |
+| [`extraction_agent.py`](extraction_agent.py) | Extracts core metadata (company name, web domain) from events and flags whether the information set is complete, ready for richer parsing extensions. |
+| [`human_in_loop_agent.py`](human_in_loop_agent.py) | Facilitates human-in-the-loop interactions for gathering missing event data and confirming dossier creation via a pluggable communication backend or built-in simulator. |
+| [`master_workflow_agent.py`](master_workflow_agent.py) | Implements the end-to-end business logic: polls events, detects triggers, performs extraction, coordinates with humans, and forwards confirmed events downstream. |
+| [`s3_storage_agent.py`](s3_storage_agent.py) | Uploads generated files to Amazon S3 using the configured credentials. |
+| [`trigger_detection_agent.py`](trigger_detection_agent.py) | Detects hard and soft trigger phrases in event summaries and descriptions using normalised keyword matching. |
+| [`workflow_orchestrator.py`](workflow_orchestrator.py) | High-level orchestrator that initialises the `MasterWorkflowAgent`, handles error resilience, and finalises runs such as optional S3 log uploads. |
 
 ## Extending agents
 

--- a/integration/README.md
+++ b/integration/README.md
@@ -7,7 +7,7 @@ Google Workspace APIs used for polling calendar events and related contacts.
 
 | File | Purpose |
 |------|---------|
-| [`google_calendar_integration.py`](google_calendar_integration.py) | Handles OAuth credential loading, access-token refresh, and REST calls to the Google Calendar API. Provides `list_events` for polling events within configurable windows. |
+| [`google_calendar_integration.py`](google_calendar_integration.py) | Handles OAuth credential loading, access-token refresh, and REST calls to the Google Calendar API, including a `list_events` helper for polling events within configurable windows. |
 | [`google_contacts_integration.py`](google_contacts_integration.py) | Provides a read-only wrapper around the Google People API to fetch organiser contact details using an existing access token. |
 
 Both integrations rely on the configuration documented in [`config/README.md`](../config/README.md).

--- a/logs/README.md
+++ b/logs/README.md
@@ -8,8 +8,8 @@ Amazon S3 for centralised auditing.
 
 | File | Description |
 |------|-------------|
-| [`event_log_manager.py`](event_log_manager.py) | Provides `get_event_log_manager` to create a ready-to-use log manager that writes structured JSON lines for event activity. Includes S3 upload support when configured. |
-| [`workflow_log_manager.py`](workflow_log_manager.py) | Supplies a `WorkflowLogManager` class for appending run-level log entries (success, failure, escalation) with optional error payloads. |
+| [`event_log_manager.py`](event_log_manager.py) | Provides `get_event_log_manager` to create a ready-to-use log manager that writes structured JSON lines for event activity with optional S3 upload support. |
+| [`workflow_log_manager.py`](workflow_log_manager.py) | Supplies a `WorkflowLogManager` class for appending run-level log entries such as success, failure, or escalation with optional error payloads. |
 | [`__init__.py`](__init__.py) | Exposes convenience factories for importing the log managers directly from the package. |
 
 ## Usage

--- a/utils/README.md
+++ b/utils/README.md
@@ -7,7 +7,7 @@ integrations.
 
 | File | Description |
 |------|-------------|
-| [`duplicate_checker.py`](duplicate_checker.py) | Provides a simple `DuplicateChecker` class for determining whether an event ID has already been processed. Intended to be extended with more advanced deduplication logic. |
+| [`duplicate_checker.py`](duplicate_checker.py) | Provides a simple `DuplicateChecker` class for determining whether an event ID has already been processed while remaining open to richer deduplication strategies. |
 | [`text_normalization.py`](text_normalization.py) | Offers Unicode-aware normalisation utilities that strip diacritics, collapse whitespace, and perform case folding with memoisation. |
 | [`trigger_loader.py`](trigger_loader.py) | Loads trigger words from environment variables and fallback files, normalises them, and removes duplicates before they reach the trigger detection agent. |
 


### PR DESCRIPTION
## Summary
- keep agent README table rows on a single line for consistent column widths
- align integration and logs README tables with clearer phrasing in each cell
- simplify utils README table descriptions while preventing forced line breaks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5cc16a39c832ba1d5d2f045fe5f2a