### PR TITLE
Fix flake8 blank line warnings

### DIFF
--- a/ARCHIVE/polling_trigger.py
+++ b/ARCHIVE/polling_trigger.py
@@ -181,4 +181,3 @@ if __name__ == "__main__":
         main()
     except Exception as e:
         logger.error(f"Polling workflow failed: {e}", exc_info=True)
-

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -10,4 +10,3 @@ __all__ = [
     "extraction_agent",
     "postgres_storage_agent",
 ]
-

--- a/agents/postgres_storage_agent.py
+++ b/agents/postgres_storage_agent.py
@@ -96,4 +96,3 @@ class PostgresStorageAgent:
                     "Failed to store '%s' in PostgreSQL: %s", target_name, error
                 )
             return False
-

--- a/agents/s3_storage_agent.py
+++ b/agents/s3_storage_agent.py
@@ -21,4 +21,3 @@ class S3StorageAgent:
         raise RuntimeError(
             "S3 storage has been disabled. Configure PostgresStorageAgent instead."
         )
-

--- a/agents/workflow_orchestrator.py
+++ b/agents/workflow_orchestrator.py
@@ -59,4 +59,3 @@ class WorkflowOrchestrator:
             logger.error("Failed to persist log file to PostgreSQL", exc_info=True)
 
         logger.info("Orchestration finalized.")
-

--- a/config/config.py
+++ b/config/config.py
@@ -89,4 +89,3 @@ class Settings:
 
 # Notes: Singleton instance for importing settings in other modules
 settings = Settings()
-

--- a/logs/__init__.py
+++ b/logs/__init__.py
@@ -47,4 +47,3 @@ def get_event_log_manager(
 
     target_table = table_name or settings.postgres_event_log_table
     return EventLogManager(target_dsn, table_name=target_table)
-

--- a/logs/event_log_manager.py
+++ b/logs/event_log_manager.py
@@ -115,4 +115,3 @@ class EventLogManager:
 # Example:
 # manager = EventLogManager("postgresql://user:pass@localhost/db")
 # manager.write_event_log("123", {"status": "done"})
-

--- a/logs/workflow_log_manager.py
+++ b/logs/workflow_log_manager.py
@@ -87,4 +87,3 @@ class WorkflowLogManager:
 # Example:
 # wlm = WorkflowLogManager("postgresql://user:pass@localhost/db")
 # wlm.append_log("run42", "start", "Workflow started", event_id="evt123")
-

--- a/startup_check.py
+++ b/startup_check.py
@@ -81,4 +81,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -40,4 +40,3 @@ def test_postgres_table_defaults(monkeypatch):
     assert settings.postgres_event_log_table == "event_logs"
     assert settings.postgres_workflow_log_table == "workflow_logs"
     assert settings.postgres_file_log_table == "workflow_log_files"
-

--- a/tests/test_logs_init.py
+++ b/tests/test_logs_init.py
@@ -66,4 +66,3 @@ def test_get_event_log_manager_prefers_argument(monkeypatch):
 
     assert manager.dsn == "postgresql://explicit/db"
     assert manager.table_name == "explicit_table"
-


### PR DESCRIPTION
## Summary
- remove trailing blank lines flagged by flake8 across agents, logging, config, and tests

## Testing
- flake8

------
https://chatgpt.com/codex/tasks/task_e_68d6c611d4cc832ba881f05fbb17dbff