### PR TITLE
Adjust default log storage location

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Individual agents can also be instantiated and exercised directly for targeted t
 - **[`integration/`](integration/README.md):** Google Calendar and Google Contacts API integrations, including OAuth token handling.
 - **[`config/`](config/README.md):** Centralised configuration loader and trigger word resources.
 - **[`logs/`](logs/README.md):** Structured event/workflow logging backed by the local filesystem.
+- **[`log_storage/`](log_storage/README.md):** Default on-disk location for generated event and workflow logs.
 - **[`utils/`](utils/README.md):** Cross-cutting utilities for text normalisation, trigger loading, and duplicate detection.
 - **[`templates/`](templates/README.md):** Shared communication templates (emails, notifications).
 - **[`extraction/`](extraction/README.md):** Extension point for advanced data extraction pipelines.
@@ -67,7 +68,7 @@ Individual agents can also be instantiated and exercised directly for targeted t
 
 ## Logging and observability
 
-Dedicated log managers in [`logs/`](logs/README.md) persist event and workflow logs on the local filesystem. The `MasterWorkflowAgent` exposes a `finalize_run_logs` helper that the orchestrator calls after each run to record log metadata.
+Dedicated log managers in [`logs/`](logs/README.md) persist event and workflow logs on the local filesystem. Generated log artefacts default to [`log_storage/run_history`](log_storage/README.md), keeping them out of the repository root. The `MasterWorkflowAgent` exposes a `finalize_run_logs` helper that the orchestrator calls after each run to record log metadata.
 
 ## Human-in-the-loop interactions
 

--- a/config/README.md
+++ b/config/README.md
@@ -17,7 +17,7 @@ to poll events.
 | `GOOGLE_TOKEN_URI` | Token endpoint URL; defaults to Google's standard OAuth token URI when not provided. | _optional_ |
 | `GOOGLE_CALENDAR_ID` | Calendar identifier to poll (e.g., `primary` or an email address). | `info@condata.io` |
 | `TRIGGER_WORDS` | Comma-separated list of trigger words that override the default list and the contents of `trigger_words.txt`. | _optional_ |
-| `LOG_STORAGE_DIR` | Root directory for storing workflow run artefacts. | `<repo>/logs/run_history` |
+| `LOG_STORAGE_DIR` | Root directory for storing workflow run artefacts. | `<repo>/log_storage/run_history` |
 | `EVENT_LOG_DIR` | Override for event log storage (defaults to a subdirectory of `LOG_STORAGE_DIR`). | `<LOG_STORAGE_DIR>/events` |
 | `WORKFLOW_LOG_DIR` | Override for workflow log storage. | `<LOG_STORAGE_DIR>/workflows` |
 | `RUN_LOG_DIR` | Override for per-run log files. | `<LOG_STORAGE_DIR>/runs` |

--- a/config/config.py
+++ b/config/config.py
@@ -75,7 +75,7 @@ class Settings:
         self.cal_lookback_days: int = _get_int_env("CAL_LOOKBACK_DAYS", 1)
 
         project_root = Path(__file__).resolve().parents[1]
-        default_log_root = project_root / "logs" / "run_history"
+        default_log_root = project_root / "log_storage" / "run_history"
 
         self.log_storage_dir: Path = _get_path_env("LOG_STORAGE_DIR", default_log_root)
         self.event_log_dir: Path = _get_path_env(

--- a/init_repo_structure.py
+++ b/init_repo_structure.py
@@ -3,6 +3,7 @@ import os
 folders = [
     "agents",
     "logs",
+    "log_storage",
     "templates",
     "polling",
     "extraction",
@@ -15,6 +16,7 @@ folders = [
 placeholders = {
     "agents/.gitkeep": "",
     "logs/.gitkeep": "",
+    "log_storage/.gitkeep": "",
     "templates/.gitkeep": "",
     "tests/__init__.py": "# Test-Modul-Initialisierung\n",
     "polling/README.md": (

--- a/log_storage/README.md
+++ b/log_storage/README.md
@@ -1,0 +1,9 @@
+# Log storage directory
+
+This directory is reserved for runtime log artefacts produced by the workflow
+agents. By default the configuration stores run outputs under
+`log_storage/run_history`, separating generated files from the repository root.
+
+> **Note:** The directory is kept in version control with a placeholder file so
+> that fresh clones have a consistent location for log output. Actual log files
+> can be safely deleted or ignored as needed.

--- a/logs/README.md
+++ b/logs/README.md
@@ -21,5 +21,5 @@ log_manager = get_event_log_manager()
 log_manager.write_event_log("event-123", {"status": "started"})
 ```
 
-By default logs are stored under ``logs/run_history`` within the repository. Override the location with the ``LOG_STORAGE_DIR`` or ``EVENT_LOG_DIR`` environment variables when running the workflow.
+By default logs are stored under ``log_storage/run_history`` within the repository. Override the location with the ``LOG_STORAGE_DIR`` or ``EVENT_LOG_DIR`` environment variables when running the workflow.
 

--- a/logs/event_log_manager.py
+++ b/logs/event_log_manager.py
@@ -71,5 +71,5 @@ class EventLogManager:
 
 
 # Example:
-# manager = EventLogManager(Path("logs/run_history/events"))
+# manager = EventLogManager(Path("log_storage/run_history/events"))
 # manager.write_event_log("123", {"status": "done"})

--- a/logs/workflow_log_manager.py
+++ b/logs/workflow_log_manager.py
@@ -60,5 +60,5 @@ class WorkflowLogManager:
 
 
 # Example:
-# wlm = WorkflowLogManager(Path("logs/run_history/workflows"))
+# wlm = WorkflowLogManager(Path("log_storage/run_history/workflows"))
 # wlm.append_log("run42", "start", "Workflow started", event_id="evt123")

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -22,7 +22,7 @@ def test_log_storage_dir_defaults(monkeypatch):
 
     settings = reload_settings()
 
-    expected = Path(__file__).resolve().parents[1] / "logs" / "run_history"
+    expected = Path(__file__).resolve().parents[1] / "log_storage" / "run_history"
     assert settings.log_storage_dir == expected
     assert settings.event_log_dir == expected / "events"
     assert settings.workflow_log_dir == expected / "workflows"


### PR DESCRIPTION
## Summary
- move the default filesystem target for runtime logs to `log_storage/run_history`
- document the new storage directory across configuration and repository docs
- add a tracked placeholder directory for log artefacts and update initialisation helpers

## Testing
- `pytest tests/test_config_settings.py`


------
https://chatgpt.com/codex/tasks/task_e_68d6cdb55670832ba59bac30f4b93500