### PR TITLE
Add agent interfaces and configurable factory

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -9,6 +9,7 @@ environments.
 
 | File | Responsibility |
 |------|----------------|
+| [`crm_agent.py`](crm_agent.py) | Default CRM sink that logs qualified events. Replace it with a HubSpot, Salesforce, or custom integration by implementing the CRM interface. |
 | [`email_agent.py`](email_agent.py) | Sends transactional emails via SMTP using plain text and optional HTML bodies while logging delivery success or failure. |
 | [`event_polling_agent.py`](event_polling_agent.py) | Connects to Google Calendar and Google Contacts to poll upcoming events, related organiser data, and filters out noise such as birthday reminders. |
 | [`extraction_agent.py`](extraction_agent.py) | Extracts core metadata (company name, web domain) from events and flags whether the information set is complete, ready for richer parsing extensions. |
@@ -18,14 +19,45 @@ environments.
 | [`trigger_detection_agent.py`](trigger_detection_agent.py) | Detects hard and soft trigger phrases in event summaries and descriptions using normalised keyword matching. |
 | [`workflow_orchestrator.py`](workflow_orchestrator.py) | High-level orchestrator that initialises the `MasterWorkflowAgent`, handles error resilience, and finalises runs by recording local log metadata. |
 
-## Extending agents
+## Extension points
 
-* **Add new automation steps** by creating dedicated agent classes that expose a clear
-  method contract (e.g., `process`, `send`, `validate`).
-* **Provide dependency injection** through constructor parameters so agents can be reused in
-  different contexts and unit tested in isolation.
-* **Keep orchestration concerns** in `workflow_orchestrator.py`; agents themselves should
-  remain side-effect focused and composable.
+Reusable abstract base classes live in [`interfaces/`](interfaces). They define the minimum
+surface area that each workflow stage must expose:
+
+| Interface | Required methods | Default implementation |
+|-----------|-----------------|------------------------|
+| `BasePollingAgent` | `poll()`, `poll_contacts()` | [`EventPollingAgent`](event_polling_agent.py) |
+| `BaseTriggerAgent` | `check(event)` | [`TriggerDetectionAgent`](trigger_detection_agent.py) |
+| `BaseExtractionAgent` | `extract(event)` | [`ExtractionAgent`](extraction_agent.py) |
+| `BaseHumanAgent` | `request_info(event, extracted)`, `request_dossier_confirmation(event, info)` | [`HumanInLoopAgent`](human_in_loop_agent.py) |
+| `BaseCrmAgent` | `send(event, info)` | [`LoggingCrmAgent`](crm_agent.py) |
+
+Concrete implementations register themselves with the registry defined in
+[`factory.py`](factory.py) using the `@register_agent` decorator. The factory supports naming
+multiple variants per interface and exposes `create_agent()` to instantiate them on demand.
+
+## Selecting agents via configuration
+
+`MasterWorkflowAgent` resolves all dependencies through the factory. Override the default
+implementations with either environment variables or a configuration file:
+
+* **Environment variables** – set `POLLING_AGENT`, `TRIGGER_AGENT`, `EXTRACTION_AGENT`,
+  `HUMAN_AGENT`, or `CRM_AGENT` to the registered name of an alternative implementation.
+* **Configuration file** – point `AGENT_CONFIG_FILE` to a JSON or YAML document containing an
+  `agents` section. Example:
+
+```yaml
+agents:
+  polling: "custom_polling"
+  crm_agent: "hubspot"
+```
+
+## Implementing a custom agent
+
+1. Create a class that subclasses the relevant base interface.
+2. Decorate the class with `@register_agent(<Interface>, "my_agent", is_default=False)`.
+3. Optionally add docs/tests.
+4. Select the new implementation via configuration.
 
 Refer to [`tests/test_master_workflow_agent_hitl.py`](../tests/test_master_workflow_agent_hitl.py)
 for examples of orchestrating agents within the broader workflow.

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -9,4 +9,7 @@ __all__ = [
     "email_agent",
     "extraction_agent",
     "local_storage_agent",
+    "crm_agent",
+    "factory",
+    "interfaces",
 ]

--- a/agents/crm_agent.py
+++ b/agents/crm_agent.py
@@ -1,0 +1,20 @@
+"""Simple CRM agent implementation used as the default workflow sink."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Mapping
+
+from agents.factory import register_agent
+from agents.interfaces import BaseCrmAgent
+
+logger = logging.getLogger(__name__)
+
+
+@register_agent(BaseCrmAgent, "logging_crm", "default", is_default=True)
+class LoggingCrmAgent(BaseCrmAgent):
+    """Default CRM agent that logs outgoing payloads locally."""
+
+    def send(self, event: Mapping[str, Any], info: Mapping[str, Any]) -> None:
+        event_id = event.get("id") if isinstance(event, Mapping) else None
+        logger.info("Sending event %s to CRM with info: %s", event_id, dict(info))

--- a/agents/event_polling_agent.py
+++ b/agents/event_polling_agent.py
@@ -1,19 +1,24 @@
 import logging
+from typing import Any, Dict, Iterable
+
+from agents.factory import register_agent
+from agents.interfaces import BasePollingAgent
 from integration.google_calendar_integration import GoogleCalendarIntegration
 from integration.google_contacts_integration import GoogleContactsIntegration
 
 logger = logging.getLogger(__name__)
 
 
-class EventPollingAgent:
-    def __init__(self, config=None):
+@register_agent(BasePollingAgent, "event_polling", "default", is_default=True)
+class EventPollingAgent(BasePollingAgent):
+    def __init__(self, config: Any = None):
         self.config = config
         self.calendar = GoogleCalendarIntegration()
         # Access token wird per Calendar-Integration gemanaged
         self.contacts = None
 
     @staticmethod
-    def _is_birthday_event(event: dict) -> bool:
+    def _is_birthday_event(event: Dict[str, Any]) -> bool:
         """Return ``True`` if the given event represents a birthday entry."""
 
         if not isinstance(event, dict):
@@ -45,7 +50,7 @@ class EventPollingAgent:
 
         return False
 
-    def poll(self):
+    def poll(self) -> Iterable[Dict[str, Any]]:
         """Polls calendar events (read-only) and logs them, skipping birthday entries."""
         try:
             events = self.calendar.list_events(max_results=100)
@@ -63,7 +68,7 @@ class EventPollingAgent:
             logger.error(f"Google Calendar polling failed: {e}")
             raise
 
-    def poll_contacts(self):
+    def poll_contacts(self) -> Iterable[Dict[str, Any]]:
         """
         Polls contacts (read-only) and logs them.
         """

--- a/agents/extraction_agent.py
+++ b/agents/extraction_agent.py
@@ -3,11 +3,16 @@
 # (such as company name and web domain) from event dictionaries.
 # This version implements basic logic and can be extended to use NLP or regex.
 
-import re
 import logging
+import re
+from typing import Any, Dict
+
+from agents.factory import register_agent
+from agents.interfaces import BaseExtractionAgent
 
 
-class ExtractionAgent:
+@register_agent(BaseExtractionAgent, "extraction", "default", is_default=True)
+class ExtractionAgent(BaseExtractionAgent):
     """
     Agent for extracting required information (e.g., company name, web domain)
     from an event dictionary.
@@ -16,7 +21,7 @@ class ExtractionAgent:
     def __init__(self):
         pass
 
-    def extract(self, event):
+    def extract(self, event: Dict[str, Any]) -> Dict[str, Any]:
         """
         Extracts the company name and web domain from the event data.
         Returns a dictionary with the extracted info and a completeness flag.

--- a/agents/factory.py
+++ b/agents/factory.py
@@ -1,0 +1,98 @@
+"""Factory utilities and registry for workflow agents."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Dict, Iterable, MutableMapping, Optional, Type, TypeVar
+
+from agents.interfaces import (
+    BaseCrmAgent,
+    BaseExtractionAgent,
+    BaseHumanAgent,
+    BasePollingAgent,
+    BaseTriggerAgent,
+)
+
+TAgent = TypeVar("TAgent")
+
+_AgentRegistry = MutableMapping[Type[Any], Dict[str, Type[Any]]]
+
+_REGISTRY: _AgentRegistry = defaultdict(dict)
+_DEFAULTS: Dict[Type[Any], str] = {}
+
+
+def register_agent(
+    interface: Type[TAgent],
+    *names: str,
+    is_default: bool = False,
+) -> Any:
+    """Register a concrete implementation for the given interface."""
+
+    if not names:
+        raise ValueError("At least one registry name must be provided.")
+
+    def decorator(cls: Type[TAgent]) -> Type[TAgent]:
+        if not issubclass(cls, interface):
+            raise TypeError(
+                f"{cls.__name__} must inherit from {interface.__name__} to register."
+            )
+
+        registry = _REGISTRY[interface]
+        for name in names:
+            registry[name] = cls
+
+        if is_default or interface not in _DEFAULTS:
+            _DEFAULTS[interface] = names[0]
+
+        return cls
+
+    return decorator
+
+
+def create_agent(
+    interface: Type[TAgent],
+    name: Optional[str] = None,
+    **kwargs: Any,
+) -> TAgent:
+    """Instantiate an agent from the registry."""
+
+    registry = _REGISTRY.get(interface)
+    if not registry:
+        raise KeyError(f"No agents registered for interface {interface.__name__}.")
+
+    if not name:
+        default_name = _DEFAULTS.get(interface)
+        if not default_name:
+            raise KeyError(
+                f"No default agent registered for interface {interface.__name__}."
+            )
+        name = default_name
+
+    cls = registry.get(name)
+    if cls is None:
+        available = ", ".join(sorted(registry)) or "<none>"
+        raise KeyError(
+            f"Agent '{name}' is not registered for interface {interface.__name__}. "
+            f"Available options: {available}."
+        )
+
+    return cls(**kwargs)
+
+
+def available_agents(interface: Type[Any]) -> Iterable[str]:
+    """Return the registered names for the supplied interface."""
+
+    registry = _REGISTRY.get(interface, {})
+    return sorted(registry.keys())
+
+
+__all__ = [
+    "BaseCrmAgent",
+    "BaseExtractionAgent",
+    "BaseHumanAgent",
+    "BasePollingAgent",
+    "BaseTriggerAgent",
+    "available_agents",
+    "create_agent",
+    "register_agent",
+]

--- a/agents/human_in_loop_agent.py
+++ b/agents/human_in_loop_agent.py
@@ -2,6 +2,9 @@ import inspect
 import logging
 from typing import Any, Dict, Optional
 
+from agents.factory import register_agent
+from agents.interfaces import BaseHumanAgent
+
 logger = logging.getLogger(__name__)
 
 # Notes:
@@ -10,7 +13,8 @@ logger = logging.getLogger(__name__)
 # the agent falls back to a deterministic simulation for demo/testing.
 
 
-class HumanInLoopAgent:
+@register_agent(BaseHumanAgent, "human_in_loop", "default", is_default=True)
+class HumanInLoopAgent(BaseHumanAgent):
     def __init__(self, communication_backend: Optional[Any] = None) -> None:
         """
         Create the HITL agent.

--- a/agents/interfaces/__init__.py
+++ b/agents/interfaces/__init__.py
@@ -1,0 +1,17 @@
+"""Shared abstract base classes for workflow agents."""
+
+from .base import (
+    BaseCrmAgent,
+    BaseExtractionAgent,
+    BaseHumanAgent,
+    BasePollingAgent,
+    BaseTriggerAgent,
+)
+
+__all__ = [
+    "BaseCrmAgent",
+    "BaseExtractionAgent",
+    "BaseHumanAgent",
+    "BasePollingAgent",
+    "BaseTriggerAgent",
+]

--- a/agents/interfaces/base.py
+++ b/agents/interfaces/base.py
@@ -1,0 +1,54 @@
+"""Abstract base classes for agent extension points."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Iterable, Mapping
+
+
+class BasePollingAgent(ABC):
+    """Contract for agents that retrieve events from external systems."""
+
+    @abstractmethod
+    def poll(self) -> Iterable[Mapping[str, Any]]:
+        """Yield event payloads that should be processed by the workflow."""
+
+    @abstractmethod
+    def poll_contacts(self) -> Iterable[Mapping[str, Any]]:
+        """Optionally yield contact payloads associated with the events."""
+
+
+class BaseTriggerAgent(ABC):
+    """Contract for agents that detect triggers on events."""
+
+    @abstractmethod
+    def check(self, event: Mapping[str, Any]) -> Dict[str, Any]:
+        """Return structured trigger detection information for an event."""
+
+
+class BaseExtractionAgent(ABC):
+    """Contract for agents that extract structured information from events."""
+
+    @abstractmethod
+    def extract(self, event: Mapping[str, Any]) -> Dict[str, Any]:
+        """Return structured information extracted from an event payload."""
+
+
+class BaseHumanAgent(ABC):
+    """Contract for human-in-the-loop escalation and confirmation flows."""
+
+    @abstractmethod
+    def request_info(self, event: Mapping[str, Any], extracted: Dict[str, Any]) -> Dict[str, Any]:
+        """Request missing information from a human collaborator."""
+
+    @abstractmethod
+    def request_dossier_confirmation(self, event: Mapping[str, Any], info: Mapping[str, Any]) -> Dict[str, Any]:
+        """Ask whether a dossier should be produced for the supplied event."""
+
+
+class BaseCrmAgent(ABC):
+    """Contract for agents that persist qualified events into a CRM system."""
+
+    @abstractmethod
+    def send(self, event: Mapping[str, Any], info: Mapping[str, Any]) -> None:
+        """Persist the event with the extracted information into the CRM system."""

--- a/agents/trigger_detection_agent.py
+++ b/agents/trigger_detection_agent.py
@@ -1,10 +1,13 @@
 import re
-from typing import List, Optional, Dict, Any, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
+from agents.factory import register_agent
+from agents.interfaces import BaseTriggerAgent
 from utils.text_normalization import normalize_text
 
 
-class TriggerDetectionAgent:
+@register_agent(BaseTriggerAgent, "trigger_detection", "default", is_default=True)
+class TriggerDetectionAgent(BaseTriggerAgent):
     def __init__(self, trigger_words: Optional[List[str]] = None):
         if trigger_words:
             normalised = [normalize_text(word) for word in trigger_words]


### PR DESCRIPTION
## Summary
- add shared abstract interfaces for each agent category and a registry-based factory
- refactor the default agents to implement the new interfaces, including a logging CRM agent
- resolve workflow dependencies through configuration-driven factory lookups and document the extension points

## Testing
- pytest tests/test_master_workflow_agent_hitl.py

------
https://chatgpt.com/codex/tasks/task_e_68d6f9d791b0832b8ee06f24197f9452