### PR TITLE
Add dynamic LLM configuration support and watcher

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -21,12 +21,52 @@ to poll events.
 | `EVENT_LOG_DIR` | Override for event log storage (defaults to a subdirectory of `LOG_STORAGE_DIR`). | `<LOG_STORAGE_DIR>/events` |
 | `WORKFLOW_LOG_DIR` | Override for workflow log storage. | `<LOG_STORAGE_DIR>/workflows` |
 | `RUN_LOG_DIR` | Override for per-run log files. | `<LOG_STORAGE_DIR>/runs` |
+| `LLM_CONFIDENCE_THRESHOLD_TRIGGER` | Minimum trigger-detection confidence required to treat an LLM response as authoritative. | `0.6` |
+| `LLM_CONFIDENCE_THRESHOLD_EXTRACTION` | Minimum extraction confidence before using the structured payload. | `0.55` |
+| `LLM_COST_CAP_DAILY` | Daily spend limit (USD) for LLM usage across all agents. | `25.0` |
+| `LLM_COST_CAP_MONTHLY` | Monthly spend limit (USD) for LLM usage across all agents. | `500.0` |
+| `LLM_RETRY_BUDGET_TRIGGER` | Number of permitted trigger-detection retries when an LLM is uncertain or fails. | `2` |
+| `LLM_RETRY_BUDGET_EXTRACTION` | Number of permitted extraction retries when an LLM is uncertain or fails. | `2` |
 
 Set `SETTINGS_SKIP_DOTENV=1` to bypass `.env` loading (useful for automated tests that inject configuration via environment variables).
 
 If `TRIGGER_WORDS` is not defined, the system falls back to the newline-separated list in
 [`trigger_words.txt`](trigger_words.txt). Empty lines and comments (lines starting with `#`)
 inside the file are ignored.
+
+## LLM configuration and live reloading
+
+Confidence thresholds, cost caps, and retry budgets for LLM-backed agents are exposed via the
+`settings.llm_confidence_thresholds`, `settings.llm_cost_caps`, and `settings.llm_retry_budgets`
+dictionaries. Defaults can be overridden via environment variables using the
+`LLM_CONFIDENCE_THRESHOLD_*`, `LLM_COST_CAP_*`, and `LLM_RETRY_BUDGET_*` prefixes. For example,
+the following `.env` entries raise the extraction confidence threshold and reduce the daily
+spend limit:
+
+```dotenv
+LLM_CONFIDENCE_THRESHOLD_EXTRACTION=0.75
+LLM_COST_CAP_DAILY=10
+```
+
+Structured configuration files referenced by `AGENT_CONFIG_FILE` may also include an `llm` block
+to override these values:
+
+```yaml
+llm:
+  confidence_thresholds:
+    trigger: 0.7
+    extraction: 0.8
+  cost_caps:
+    daily: 15
+    weekly: 50
+  retry_budgets:
+    trigger: 1
+    extraction: 3
+```
+
+When watchdog is available, the application monitors the `.env` file and the optional YAML/JSON
+configuration for changes. Updates are applied live to the running `MasterWorkflowAgent` and any
+other consumer of `settings`, avoiding the need to restart long-lived processes.
 
 ## Usage
 

--- a/config/watcher.py
+++ b/config/watcher.py
@@ -1,0 +1,130 @@
+"""Dynamic configuration watchers for updating LLM settings at runtime."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Callable, Iterable, Optional, Set
+
+from dotenv import load_dotenv
+
+from config.config import Settings
+
+try:  # pragma: no cover - optional dependency handling
+    from watchdog.events import FileSystemEventHandler
+    from watchdog.observers import Observer
+except ImportError:  # pragma: no cover - graceful degradation
+    FileSystemEventHandler = object  # type: ignore
+    Observer = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+class _LlmEventHandler(FileSystemEventHandler):
+    """Watchdog event handler that delegates to a callback."""
+
+    def __init__(self, callback: Callable[[Path], None]) -> None:
+        self._callback = callback
+
+    def on_modified(self, event):  # type: ignore[override]
+        if getattr(event, "is_directory", False):
+            return
+        self._callback(Path(event.src_path))
+
+    def on_created(self, event):  # type: ignore[override]
+        if getattr(event, "is_directory", False):
+            return
+        self._callback(Path(event.src_path))
+
+    def on_moved(self, event):  # type: ignore[override]
+        if getattr(event, "is_directory", False):
+            return
+        self._callback(Path(event.dest_path))
+
+
+class LlmConfigurationWatcher:
+    """Watch `.env` and agent configuration files for LLM related updates."""
+
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        on_update: Optional[Callable[[Settings], None]] = None,
+        extra_paths: Optional[Iterable[Path]] = None,
+    ) -> None:
+        self._settings = settings
+        self._on_update = on_update
+
+        files_to_watch: Set[Path] = set()
+        if os.getenv("SETTINGS_SKIP_DOTENV") != "1":
+            files_to_watch.add(Path(".env").resolve())
+        if settings.agent_config_file:
+            files_to_watch.add(settings.agent_config_file.resolve())
+        if extra_paths:
+            files_to_watch.update(Path(p).resolve() for p in extra_paths)
+
+        self._candidate_files: Set[Path] = files_to_watch
+        self._directories: Set[Path] = {
+            path.parent for path in self._candidate_files if path.parent.exists()
+        }
+
+        self._observer: Optional[Observer] = None
+        self._lock = threading.Lock()
+        self._handler = _LlmEventHandler(self._handle_event)
+
+    def start(self) -> bool:
+        """Start watching for configuration changes (if watchdog is available)."""
+
+        if Observer is None:
+            logger.warning(
+                "watchdog is not installed; dynamic LLM configuration updates are disabled."
+            )
+            return False
+
+        if not self._directories:
+            logger.debug("No configuration files found for LLM watcher; skipping start.")
+            return False
+
+        self._observer = Observer()
+        for directory in self._directories:
+            self._observer.schedule(self._handler, str(directory), recursive=False)
+        self._observer.start()
+        logger.debug(
+            "Started LLM configuration watcher for %s",
+            [str(path) for path in self._candidate_files],
+        )
+        return True
+
+    def stop(self) -> None:
+        """Stop the watcher if it is running."""
+
+        if self._observer is None:
+            return
+        self._observer.stop()
+        self._observer.join(timeout=2)
+        self._observer = None
+
+    def _handle_event(self, path: Path) -> None:
+        resolved = path.resolve()
+        if resolved not in self._candidate_files:
+            return
+
+        with self._lock:
+            if os.getenv("SETTINGS_SKIP_DOTENV") != "1" and any(
+                candidate.name == ".env" and resolved == candidate
+                for candidate in self._candidate_files
+            ):
+                load_dotenv(override=True)
+
+            try:
+                self._settings.refresh_llm_configuration()
+            except EnvironmentError as exc:
+                logger.error("Failed to refresh LLM configuration: %s", exc)
+                return
+
+            logger.info("Reloaded LLM configuration from %s", path)
+            if self._on_update:
+                self._on_update(self._settings)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Core dependencies
 python-dotenv>=1.0,<2.0       # Load environment variables from .env file
+watchdog>=3.0,<4.0           # Monitor configuration changes at runtime
 
 # Google API support
 google-api-python-client>=2.0,<3.0


### PR DESCRIPTION
## Summary
- extend the configuration loader to expose LLM confidence thresholds, cost caps, and retry budgets with environment and YAML overrides
- introduce a watchdog-based watcher that refreshes LLM settings in running agents and gate workflow decisions on confidence thresholds
- document the new configuration parameters and add the watchdog dependency

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d703352c88832baf6f5e60a10d55b0