### PR TITLE
Ensure audit IDs are surfaced in workflow logs

### DIFF
--- a/agents/master_workflow_agent.py
+++ b/agents/master_workflow_agent.py
@@ -100,11 +100,21 @@ class MasterWorkflowAgent:
             self.human_agent.set_audit_log(self.audit_log)
 
         # Configure logger to write to the unique per-run file
+        for existing_handler in list(logger.handlers):
+            if isinstance(existing_handler, logging.FileHandler) and getattr(
+                existing_handler, "_master_agent_handler", False
+            ):
+                logger.removeHandler(existing_handler)
+                existing_handler.close()
+
         file_handler = logging.FileHandler(
             self.log_file_path, mode="w", encoding="utf-8"
         )
         formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
         file_handler.setFormatter(formatter)
+        file_handler.setLevel(logging.INFO)
+        setattr(file_handler, "_master_agent_handler", True)
+        logger.setLevel(logging.INFO)
         logger.addHandler(file_handler)
 
         self.llm_confidence_thresholds: Dict[str, float] = {}

--- a/tests/test_master_workflow_agent_hitl.py
+++ b/tests/test_master_workflow_agent_hitl.py
@@ -138,6 +138,10 @@ def test_audit_log_records_dossier_acceptance(tmp_path) -> None:
         assert response_entry["outcome"] == "approved"
         assert response_entry["request_type"] == "dossier_confirmation"
         assert response_entry["responder"] == "DummyBackend"
+
+        log_contents = agent.log_file_path.read_text(encoding="utf-8")
+        assert response_entry["audit_id"] in log_contents
+        assert "[audit_id=n/a]" not in log_contents
     finally:
         if agent is not None:
             agent.finalize_run_logs()
@@ -163,6 +167,10 @@ def test_audit_log_records_dossier_decline(tmp_path) -> None:
         assert {entry["stage"] for entry in entries} == {"request", "response"}
         response_entry = next(entry for entry in entries if entry["stage"] == "response")
         assert response_entry["outcome"] == "declined"
+
+        log_contents = agent.log_file_path.read_text(encoding="utf-8")
+        assert response_entry["audit_id"] in log_contents
+        assert "[audit_id=n/a]" not in log_contents
     finally:
         if agent is not None:
             agent.finalize_run_logs()
@@ -216,6 +224,10 @@ def test_audit_log_records_missing_info_flow(tmp_path) -> None:
         response_entry = next(entry for entry in entries if entry["stage"] == "response")
         assert response_entry["outcome"] == "completed"
         assert response_entry["responder"] == "simulation"
+
+        log_contents = agent.log_file_path.read_text(encoding="utf-8")
+        assert response_entry["audit_id"] in log_contents
+        assert "[audit_id=n/a]" not in log_contents
     finally:
         if agent is not None:
             agent.finalize_run_logs()


### PR DESCRIPTION
## Summary
- ensure the MasterWorkflowAgent logging handler is reset per run and captures INFO level records with the audit identifiers
- extend the human-in-the-loop integration coverage to verify audit IDs are written to the per-run workflow logs for approve, decline, and missing-info paths

## Testing
- pytest tests/test_master_workflow_agent_hitl.py

------
https://chatgpt.com/codex/tasks/task_e_68d7096d6edc832ba99cc4a38d16e7a8