### PR TITLE
Add prompt loader with versioned templates

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -12,3 +12,28 @@ update messaging without touching the automation logic.
 
 Feel free to add additional markdown, text, or HTML files to this package as the workflows
 expand to cover more communication channels.
+
+## Prompt change management
+
+Prompt definitions live in [`prompts/`](prompts) with explicit semantic version tags. Each
+prompt file must include a metadata block documenting temperature, token budgets, authorship,
+and a short changelog entry so operators can audit revisions quickly.
+
+When updating prompts:
+
+1. Introduce a new file with an incremented `version` field instead of editing an existing
+   one. This preserves the history of previous variants for reproducibility.
+2. Record the rationale for the change in the `metadata.changelog` entry.
+3. Update configuration or environment overrides if consumers should adopt the new version
+   immediately; otherwise the loader will continue serving the prior default.
+
+### Rollback procedure
+
+To roll back to an earlier prompt:
+
+1. Set the appropriate `PROMPT_VERSION_<PROMPT_NAME>` environment variable (or the matching
+   entry in the shared agent configuration file) to the desired version tag.
+2. Restart the affected services so they pick up the refreshed configuration. No file
+   changes are required because each version remains on disk.
+3. Once the incident is resolved, evaluate whether the newer prompt should be revised or
+   deprecated.

--- a/templates/prompts/customer_follow_up_v1.yaml
+++ b/templates/prompts/customer_follow_up_v1.yaml
@@ -1,0 +1,12 @@
+name: customer_follow_up
+version: v1
+metadata:
+  temperature: 0.4
+  max_tokens: 512
+  author: lifecycle-team
+  created_at: "2024-05-01"
+  changelog: Initial version drafted for onboarding sequences.
+content: |
+  You are the lifecycle automation assistant for our customer success team.
+  Draft a warm follow-up email to a new user who has not completed setup.
+  Focus on offering help, highlighting key benefits, and encouraging a reply.

--- a/templates/prompts/customer_follow_up_v2.json
+++ b/templates/prompts/customer_follow_up_v2.json
@@ -1,0 +1,12 @@
+{
+  "name": "customer_follow_up",
+  "version": "v2",
+  "metadata": {
+    "temperature": 0.25,
+    "max_tokens": 640,
+    "author": "lifecycle-team",
+    "created_at": "2024-06-10",
+    "changelog": "Streamlined call-to-action and reinforced value props."
+  },
+  "content": "You are the lifecycle automation assistant. Compose a concise follow-up reminding the user to finish onboarding, provide two bullet benefits, and invite questions."
+}

--- a/tests/unit/test_prompt_loader.py
+++ b/tests/unit/test_prompt_loader.py
@@ -1,0 +1,51 @@
+import pytest
+
+from config.config import settings
+from utils import prompt_loader
+
+
+@pytest.fixture(autouse=True)
+def reset_prompt_loader(monkeypatch):
+    original_versions = dict(settings.prompt_versions)
+    original_directory = settings.prompt_directory
+
+    prompt_loader.clear_prompt_cache()
+    yield
+
+    monkeypatch.setattr(settings, "prompt_versions", original_versions, raising=False)
+    monkeypatch.setattr(settings, "prompt_directory", original_directory, raising=False)
+    prompt_loader.clear_prompt_cache()
+
+
+def test_get_prompt_default_version_selects_latest(monkeypatch):
+    monkeypatch.setattr(settings, "prompt_versions", {}, raising=False)
+
+    prompt = prompt_loader.get_prompt("customer_follow_up")
+
+    assert prompt["version"] == "v2"
+    assert prompt["metadata"]["max_tokens"] == 640
+
+
+def test_get_prompt_respects_config_override(monkeypatch):
+    monkeypatch.setattr(settings, "prompt_versions", {"customer_follow_up": "v1"}, raising=False)
+
+    prompt = prompt_loader.get_prompt("customer_follow_up")
+
+    assert prompt["version"] == "v1"
+    assert prompt["metadata"]["temperature"] == 0.4
+
+
+def test_get_prompt_explicit_version_overrides_config(monkeypatch):
+    monkeypatch.setattr(settings, "prompt_versions", {"customer_follow_up": "v1"}, raising=False)
+
+    prompt = prompt_loader.get_prompt("customer_follow_up", version="v2")
+
+    assert prompt["version"] == "v2"
+
+
+def test_get_prompt_is_case_insensitive(monkeypatch):
+    monkeypatch.setattr(settings, "prompt_versions", {}, raising=False)
+
+    prompt = prompt_loader.get_prompt("CUSTOMER_FOLLOW_UP")
+
+    assert prompt["version"] == "v2"

--- a/utils/prompt_loader.py
+++ b/utils/prompt_loader.py
@@ -1,0 +1,181 @@
+"""Utilities for loading structured LLM prompt templates with version control."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, Mapping, MutableMapping, Optional
+
+from config.config import settings
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - optional dependency guard
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - optional dependency guard
+    yaml = None  # type: ignore
+
+_PROMPT_FILE_SUFFIXES = {".json", ".yaml", ".yml"}
+
+
+class PromptLoaderError(RuntimeError):
+    """Raised when a prompt template cannot be located or parsed."""
+
+
+class PromptDefinition(Dict[str, Any]):
+    """Container for prompt data with helper properties."""
+
+    @property
+    def version(self) -> str:
+        return str(self.get("version", ""))
+
+    @property
+    def name(self) -> str:
+        return str(self.get("name", ""))
+
+    @property
+    def metadata(self) -> Mapping[str, Any]:
+        metadata = self.get("metadata", {})
+        if not isinstance(metadata, Mapping):
+            raise PromptLoaderError(
+                f"Prompt '{self.name}' version '{self.version}' metadata must be a mapping."
+            )
+        return metadata
+
+
+def _normalise_prompt_name(name: str) -> str:
+    normalised = name.strip().lower()
+    if not normalised:
+        raise PromptLoaderError("Prompt name must be a non-empty string.")
+    return normalised
+
+
+@lru_cache(maxsize=None)
+def _prompt_index(directory: Path) -> Mapping[str, Mapping[str, Path]]:
+    index: Dict[str, Dict[str, Path]] = {}
+
+    if not directory.exists():
+        raise PromptLoaderError(f"Prompt directory '{directory}' does not exist.")
+
+    for path in directory.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.suffix.lower() not in _PROMPT_FILE_SUFFIXES:
+            continue
+
+        data = _load_prompt_file(path)
+        name = _normalise_prompt_name(str(data.get("name", path.stem)))
+        version = str(data.get("version"))
+        if not version:
+            raise PromptLoaderError(
+                f"Prompt file '{path}' does not specify a 'version' field."
+            )
+
+        index.setdefault(name, {})[version] = path
+
+    if not index:
+        raise PromptLoaderError(
+            f"No prompt templates discovered in '{directory}'."
+        )
+
+    return index
+
+
+def _load_prompt_file(path: Path) -> PromptDefinition:
+    text = path.read_text(encoding="utf-8")
+    suffix = path.suffix.lower()
+
+    if suffix == ".json":
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive branch
+            raise PromptLoaderError(f"Failed to parse JSON prompt '{path}': {exc}.") from exc
+    elif suffix in {".yaml", ".yml"}:
+        if yaml is None:  # pragma: no cover - dependency guard
+            raise PromptLoaderError(
+                "PyYAML is required to read YAML prompt templates but is not installed."
+            )
+        try:
+            data = yaml.safe_load(text) or {}
+        except yaml.YAMLError as exc:  # pragma: no cover - defensive branch
+            raise PromptLoaderError(f"Failed to parse YAML prompt '{path}': {exc}.") from exc
+    else:  # pragma: no cover - extension guard
+        raise PromptLoaderError(f"Unsupported prompt file format: '{path.suffix}'.")
+
+    if not isinstance(data, MutableMapping):
+        raise PromptLoaderError(
+            f"Prompt file '{path}' must contain a mapping at the top level."
+        )
+
+    return PromptDefinition(data)
+
+
+def _version_sort_key(version: str) -> tuple:
+    numeric_parts = [int(part) for part in re.findall(r"\d+", version)]
+    prefix = re.split(r"\d", version, maxsplit=1)[0]
+    return (prefix, numeric_parts, version)
+
+
+def clear_prompt_cache() -> None:
+    """Clear cached prompt indices, primarily for use in unit tests."""
+
+    _prompt_index.cache_clear()
+
+
+def get_prompt(name: str, version: Optional[str] = None) -> PromptDefinition:
+    """Load a prompt definition based on configured or explicit version selection."""
+
+    directory = settings.prompt_directory
+    index = _prompt_index(directory)
+    normalised_name = _normalise_prompt_name(name)
+
+    if normalised_name not in index:
+        available = ", ".join(sorted(index)) or "<none>"
+        raise PromptLoaderError(
+            f"Prompt '{name}' was not found. Available prompts: {available}."
+        )
+
+    prompt_versions = index[normalised_name]
+
+    selected_version = version
+    if selected_version is None:
+        configured = settings.prompt_versions.get(normalised_name)
+        if configured:
+            selected_version = configured
+    if selected_version is None:
+        selected_version = _latest_version(prompt_versions)
+
+    if selected_version not in prompt_versions:
+        available_versions = ", ".join(sorted(prompt_versions))
+        raise PromptLoaderError(
+            f"Prompt '{name}' version '{selected_version}' was not found. "
+            f"Available versions: {available_versions}."
+        )
+
+    path = prompt_versions[selected_version]
+    prompt = _load_prompt_file(path)
+
+    metadata = prompt.metadata
+    for field in ("temperature", "max_tokens"):
+        if field not in metadata:
+            raise PromptLoaderError(
+                f"Prompt '{prompt.name}' version '{prompt.version}' is missing metadata field '{field}'."
+            )
+
+    logger.info(
+        "Loaded prompt '%s' version '%s' from %s (temperature=%s, max_tokens=%s)",
+        prompt.name,
+        prompt.version,
+        path,
+        metadata.get("temperature"),
+        metadata.get("max_tokens"),
+    )
+
+    return prompt
+
+
+def _latest_version(version_map: Mapping[str, Path]) -> str:
+    return max(version_map, key=_version_sort_key)


### PR DESCRIPTION
## Summary
- add versioned prompt templates with metadata in `templates/prompts`
- implement a prompt loader utility that reads configuration overrides and logs usage
- document prompt change management procedures and cover the loader with unit tests

## Testing
- pytest tests/unit/test_prompt_loader.py

------
https://chatgpt.com/codex/tasks/task_e_68d71a5c0c2c832b8c4fe25cfec63246