### PR TITLE
Add cost guard with budget enforcement and metrics

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -24,6 +24,9 @@ to poll events.
 | `COMPLIANCE_MODE` | Controls default masking rules; accepts `standard` or `strict`. | `standard` |
 | `MASK_PII_IN_LOGS` | Explicit toggle to mask personal data in logs regardless of compliance mode. | `true` |
 | `MASK_PII_IN_MESSAGES` | Explicit toggle to mask personal data in HITL messages. | `false` (`true` when `COMPLIANCE_MODE=strict`) |
+| `DAILY_COST_CAP` | Aggregate daily workflow spend limit (USD) used by the runtime cost guard. | `50.0` |
+| `MONTHLY_COST_CAP` | Aggregate monthly workflow spend limit (USD) used by the runtime cost guard. | `1000.0` |
+| `SERVICE_RATE_LIMIT_*` | Per-service request ceilings evaluated by the cost guard (e.g. `SERVICE_RATE_LIMIT_OPENAI=60` for 60 calls/min). | _optional_ |
 | `PII_FIELD_WHITELIST` | Comma-separated list of additional business fields that should never be redacted. | see `config.config` defaults |
 | `LLM_CONFIDENCE_THRESHOLD_TRIGGER` | Minimum trigger-detection confidence required to treat an LLM response as authoritative. | `0.6` |
 | `LLM_CONFIDENCE_THRESHOLD_EXTRACTION` | Minimum extraction confidence before using the structured payload. | `0.55` |

--- a/config/config.py
+++ b/config/config.py
@@ -240,6 +240,12 @@ class Settings:
             "MASK_PII_IN_MESSAGES", default_mask_messages
         )
 
+        self.daily_cost_cap: float = _get_float_env("DAILY_COST_CAP", 50.0)
+        self.monthly_cost_cap: float = _get_float_env("MONTHLY_COST_CAP", 1000.0)
+        self.service_rate_limits: Dict[str, int] = _prefixed_env_mapping(
+            "SERVICE_RATE_LIMIT_", int
+        )
+
         whitelist_env = _get_env_var("PII_FIELD_WHITELIST")
         whitelist = {
             "company_name",

--- a/tests/unit/test_cost_guard.py
+++ b/tests/unit/test_cost_guard.py
@@ -1,0 +1,127 @@
+"""Unit tests for the cost guard utility."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from agents.alert_agent import AlertSeverity
+from utils.cost_guard import BudgetExceededError, CostGuard
+
+
+class DummyAlertAgent:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def send_alert(self, message, severity, context=None):  # pragma: no cover - exercised in tests
+        self.calls.append((message, severity, context or {}))
+
+
+class FakeClock:
+    def __init__(self, start: datetime) -> None:
+        self.current = start
+
+    def now(self) -> datetime:
+        return self.current
+
+    def advance(self, delta: timedelta) -> None:
+        self.current += delta
+
+    def set(self, value: datetime) -> None:
+        self.current = value
+
+
+def test_cost_guard_warns_before_limits():
+    alert_agent = DummyAlertAgent()
+    guard = CostGuard(
+        daily_cap=10.0,
+        monthly_cap=100.0,
+        service_rate_limits=None,
+        alert_agent=alert_agent,
+    )
+
+    decision = guard.authorise("openai", 9.0)
+
+    assert decision.allowed
+    assert guard.daily_spend == pytest.approx(9.0)
+    assert decision.warnings
+    assert alert_agent.calls
+    message, severity, context = alert_agent.calls[-1]
+    assert "approaching" in message
+    assert severity == AlertSeverity.WARNING
+    assert context["scope"] == "daily"
+
+
+def test_cost_guard_blocks_and_alerts_on_daily_cap():
+    alert_agent = DummyAlertAgent()
+    guard = CostGuard(
+        daily_cap=10.0,
+        monthly_cap=20.0,
+        service_rate_limits=None,
+        alert_agent=alert_agent,
+    )
+
+    guard.authorise("openai", 9.0)
+    decision = guard.authorise("openai", 2.0)
+
+    assert not decision.allowed
+    assert "Daily cost cap" in (decision.blocked_reason or "")
+    assert guard.daily_spend == pytest.approx(9.0)
+    assert alert_agent.calls
+    message, severity, context = alert_agent.calls[-1]
+    assert "limit hit" in message
+    assert severity == AlertSeverity.ERROR
+    assert context["scope"] == "daily"
+
+    with pytest.raises(BudgetExceededError):
+        guard.authorise("openai", 2.0, raise_on_block=True)
+
+
+def test_cost_guard_enforces_rate_limit():
+    clock = FakeClock(datetime(2024, 1, 1, 12, 0, 0))
+    guard = CostGuard(
+        daily_cap=100.0,
+        monthly_cap=100.0,
+        service_rate_limits={"openai": 2},
+        alert_agent=None,
+        time_provider=clock.now,
+    )
+
+    assert guard.authorise("openai", 1.0).allowed
+    clock.advance(timedelta(seconds=5))
+    assert guard.authorise("openai", 1.0).allowed
+    clock.advance(timedelta(seconds=5))
+    decision = guard.authorise("openai", 1.0)
+
+    assert not decision.allowed
+    assert "Rate limit" in (decision.blocked_reason or "")
+
+    clock.advance(timedelta(minutes=1))
+    decision = guard.authorise("openai", 1.0)
+    assert decision.allowed
+
+
+def test_cost_guard_resets_daily_and_monthly_windows():
+    clock = FakeClock(datetime(2024, 1, 30, 23, 30, 0))
+    guard = CostGuard(
+        daily_cap=10.0,
+        monthly_cap=20.0,
+        service_rate_limits=None,
+        alert_agent=None,
+        time_provider=clock.now,
+    )
+
+    guard.authorise("openai", 5.0)
+    assert guard.daily_spend == pytest.approx(5.0)
+    assert guard.monthly_spend == pytest.approx(5.0)
+
+    clock.advance(timedelta(hours=2))  # move into next day but same month
+    guard.authorise("openai", 5.0)
+    assert guard.daily_spend == pytest.approx(5.0)
+    assert guard.monthly_spend == pytest.approx(10.0)
+
+    clock.set(datetime(2024, 2, 1, 1, 0, 0))
+    guard.authorise("openai", 5.0)
+    assert guard.daily_spend == pytest.approx(5.0)
+    assert guard.monthly_spend == pytest.approx(5.0)

--- a/utils/cost_guard.py
+++ b/utils/cost_guard.py
@@ -322,4 +322,3 @@ class CostGuard:
             self.alert_agent.send_alert(message, severity, context=context)
         except Exception:  # pragma: no cover - defensive alerting
             self.logger.exception("Failed to dispatch %s alert", severity.value)
-

--- a/utils/cost_guard.py
+++ b/utils/cost_guard.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Deque, Dict, List, Mapping, MutableMapping, Optional
 
 from agents.alert_agent import AlertAgent, AlertSeverity
@@ -14,7 +14,7 @@ from utils import observability
 
 
 def _utc_now() -> datetime:
-    return datetime.now(UTC)
+    return datetime.now(timezone.utc)
 
 
 class BudgetExceededError(RuntimeError):

--- a/utils/cost_guard.py
+++ b/utils/cost_guard.py
@@ -1,0 +1,325 @@
+"""Runtime guard for tracking API spend and enforcing budget limits."""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict, deque
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any, Callable, Deque, Dict, List, Mapping, MutableMapping, Optional
+
+from agents.alert_agent import AlertAgent, AlertSeverity
+
+from utils import observability
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+class BudgetExceededError(RuntimeError):
+    """Raised when a cost guard check determines the budget has been exceeded."""
+
+
+@dataclass
+class CostDecision:
+    """Outcome of a cost guard evaluation."""
+
+    allowed: bool
+    blocked_reason: Optional[str] = None
+    warnings: List[str] = field(default_factory=list)
+    daily_spend: float = 0.0
+    monthly_spend: float = 0.0
+
+
+class CostGuard:
+    """Track cumulative spend and rate limits for downstream services."""
+
+    def __init__(
+        self,
+        *,
+        daily_cap: float,
+        monthly_cap: float,
+        service_rate_limits: Optional[Mapping[str, int]] = None,
+        alert_agent: Optional[AlertAgent] = None,
+        logger: Optional[logging.Logger] = None,
+        warning_threshold: float = 0.9,
+        rate_limit_window: timedelta = timedelta(minutes=1),
+        time_provider: Callable[[], datetime] = _utc_now,
+    ) -> None:
+        self.daily_cap = max(float(daily_cap), 0.0)
+        self.monthly_cap = max(float(monthly_cap), 0.0)
+        self.alert_agent = alert_agent
+        self.logger = logger or logging.getLogger(self.__class__.__name__)
+        self.warning_threshold = warning_threshold
+        self.rate_limit_window = rate_limit_window
+        self._now = time_provider
+
+        limits = service_rate_limits or {}
+        self.service_rate_limits: Dict[str, int] = {
+            self._normalise_service(name): int(limit)
+            for name, limit in limits.items()
+            if int(limit) > 0
+        }
+
+        start = self._now()
+        self._daily_anchor = start.date()
+        self._monthly_anchor = (start.year, start.month)
+        self._daily_spend = 0.0
+        self._monthly_spend = 0.0
+        self._service_spend: Dict[str, float] = defaultdict(float)
+        self._service_invocations: Dict[str, Deque[datetime]] = defaultdict(deque)
+        self._warned_limits: MutableMapping[str, bool] = {"daily": False, "monthly": False}
+
+    # ------------------------------------------------------------------
+    # Factory helpers
+    # ------------------------------------------------------------------
+    @classmethod
+    def from_settings(
+        cls,
+        settings: Any,
+        *,
+        alert_agent: Optional[AlertAgent] = None,
+        logger: Optional[logging.Logger] = None,
+        warning_threshold: float = 0.9,
+        rate_limit_window: timedelta = timedelta(minutes=1),
+        time_provider: Callable[[], datetime] = _utc_now,
+    ) -> "CostGuard":
+        """Instantiate a cost guard using attributes exposed on settings."""
+
+        return cls(
+            daily_cap=float(getattr(settings, "daily_cost_cap", 0.0)),
+            monthly_cap=float(getattr(settings, "monthly_cost_cap", 0.0)),
+            service_rate_limits=getattr(settings, "service_rate_limits", None),
+            alert_agent=alert_agent,
+            logger=logger,
+            warning_threshold=warning_threshold,
+            rate_limit_window=rate_limit_window,
+            time_provider=time_provider,
+        )
+
+    # ------------------------------------------------------------------
+    # Core API
+    # ------------------------------------------------------------------
+    def authorise(
+        self,
+        service: str,
+        cost: float,
+        *,
+        metadata: Optional[Mapping[str, object]] = None,
+        raise_on_block: bool = False,
+    ) -> CostDecision:
+        """Check whether a service call may proceed and record the spend."""
+
+        normalised_service = self._normalise_service(service)
+        now = self._now()
+        self._reset_if_needed(now)
+
+        cost = max(float(cost), 0.0)
+        warnings: List[str] = []
+        blocked_reason: Optional[str] = None
+
+        rate_limit_reason = self._check_rate_limit(normalised_service, now)
+        if rate_limit_reason:
+            blocked_reason = rate_limit_reason
+        else:
+            blocked_reason = self._evaluate_costs(normalised_service, cost, metadata)
+
+        if blocked_reason:
+            if raise_on_block:
+                raise BudgetExceededError(blocked_reason)
+            return CostDecision(
+                allowed=False,
+                blocked_reason=blocked_reason,
+                warnings=warnings,
+                daily_spend=self._daily_spend,
+                monthly_spend=self._monthly_spend,
+            )
+
+        self._service_invocations[normalised_service].append(now)
+        self._service_spend[normalised_service] += cost
+        self._daily_spend += cost
+        self._monthly_spend += cost
+        observability.record_cost_spend(normalised_service, cost)
+
+        warnings.extend(
+            self._evaluate_thresholds(normalised_service, metadata)
+        )
+
+        return CostDecision(
+            allowed=True,
+            warnings=warnings,
+            daily_spend=self._daily_spend,
+            monthly_spend=self._monthly_spend,
+        )
+
+    # ------------------------------------------------------------------
+    # Inspection helpers
+    # ------------------------------------------------------------------
+    @property
+    def daily_spend(self) -> float:
+        return self._daily_spend
+
+    @property
+    def monthly_spend(self) -> float:
+        return self._monthly_spend
+
+    @property
+    def service_spend(self) -> Mapping[str, float]:
+        return dict(self._service_spend)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _normalise_service(self, service: str) -> str:
+        return (service or "unknown").strip().lower() or "unknown"
+
+    def _reset_if_needed(self, now: datetime) -> None:
+        if now.date() != self._daily_anchor:
+            self.logger.debug("Resetting daily spend window: %s -> %s", self._daily_anchor, now.date())
+            self._daily_anchor = now.date()
+            self._daily_spend = 0.0
+            self._warned_limits["daily"] = False
+
+        month_anchor = (now.year, now.month)
+        if month_anchor != self._monthly_anchor:
+            self.logger.debug(
+                "Resetting monthly spend window: %s -> %s", self._monthly_anchor, month_anchor
+            )
+            self._monthly_anchor = month_anchor
+            self._monthly_spend = 0.0
+            self._warned_limits["monthly"] = False
+
+    def _check_rate_limit(self, service: str, now: datetime) -> Optional[str]:
+        limit = self.service_rate_limits.get(service)
+        if not limit:
+            return None
+
+        window_start = now - self.rate_limit_window
+        invocations = self._service_invocations[service]
+        while invocations and invocations[0] <= window_start:
+            invocations.popleft()
+
+        if len(invocations) >= limit:
+            message = (
+                f"Rate limit exceeded for {service}: {len(invocations)} calls in "
+                f"{self.rate_limit_window.total_seconds():.0f}s window (limit {limit})."
+            )
+            self.logger.warning(message)
+            observability.record_cost_limit_event(
+                "rate_limit_breach", service, limit=limit
+            )
+            return message
+
+        return None
+
+    def _evaluate_costs(
+        self,
+        service: str,
+        cost: float,
+        metadata: Optional[Mapping[str, object]],
+    ) -> Optional[str]:
+        projected_daily = self._daily_spend + cost
+        projected_monthly = self._monthly_spend + cost
+
+        if self.daily_cap and projected_daily > self.daily_cap:
+            message = (
+                f"Daily cost cap of ${self.daily_cap:.2f} exceeded by service {service}."
+            )
+            self._emit_breach_alert("daily", service, projected_daily, self.daily_cap, metadata)
+            return message
+
+        if self.monthly_cap and projected_monthly > self.monthly_cap:
+            message = (
+                f"Monthly cost cap of ${self.monthly_cap:.2f} exceeded by service {service}."
+            )
+            self._emit_breach_alert(
+                "monthly", service, projected_monthly, self.monthly_cap, metadata
+            )
+            return message
+
+        return None
+
+    def _evaluate_thresholds(
+        self,
+        service: str,
+        metadata: Optional[Mapping[str, object]],
+    ) -> List[str]:
+        messages: List[str] = []
+
+        if self.daily_cap:
+            ratio = self._daily_spend / self.daily_cap if self.daily_cap else 0.0
+            if ratio >= self.warning_threshold and not self._warned_limits["daily"]:
+                messages.append(
+                    self._emit_warning("daily", service, self._daily_spend, self.daily_cap, metadata)
+                )
+
+        if self.monthly_cap:
+            ratio = self._monthly_spend / self.monthly_cap if self.monthly_cap else 0.0
+            if ratio >= self.warning_threshold and not self._warned_limits["monthly"]:
+                messages.append(
+                    self._emit_warning(
+                        "monthly", service, self._monthly_spend, self.monthly_cap, metadata
+                    )
+                )
+
+        return [msg for msg in messages if msg]
+
+    def _emit_warning(
+        self,
+        scope: str,
+        service: str,
+        spend: float,
+        limit: float,
+        metadata: Optional[Mapping[str, object]],
+    ) -> str:
+        self._warned_limits[scope] = True
+        message = (
+            f"{scope.capitalize()} spend for {service} is approaching the limit: "
+            f"${spend:.2f} of ${limit:.2f}."
+        )
+        self.logger.warning(message)
+        observability.record_cost_limit_event("warning", service, limit=limit)
+        self._send_alert(message, AlertSeverity.WARNING, metadata, scope, spend, limit)
+        return message
+
+    def _emit_breach_alert(
+        self,
+        scope: str,
+        service: str,
+        spend: float,
+        limit: float,
+        metadata: Optional[Mapping[str, object]],
+    ) -> None:
+        observability.record_cost_limit_event("breach", service, limit=limit)
+        message = (
+            f"{scope.capitalize()} cost limit hit for {service}: ${spend:.2f} exceeds ${limit:.2f}."
+        )
+        self.logger.error(message)
+        self._send_alert(message, AlertSeverity.ERROR, metadata, scope, spend, limit)
+
+    def _send_alert(
+        self,
+        message: str,
+        severity: AlertSeverity,
+        metadata: Optional[Mapping[str, object]],
+        scope: str,
+        spend: float,
+        limit: float,
+    ) -> None:
+        if not self.alert_agent:
+            return
+
+        context = {
+            "scope": scope,
+            "spend": spend,
+            "limit": limit,
+        }
+        if metadata:
+            context.update(metadata)
+
+        try:
+            self.alert_agent.send_alert(message, severity, context=context)
+        except Exception:  # pragma: no cover - defensive alerting
+            self.logger.exception("Failed to dispatch %s alert", severity.value)
+


### PR DESCRIPTION
## Summary
- add workflow-level cost caps and service rate limits sourced from environment variables
- implement a cost guard utility that enforces spend caps, emits alerts, and records observability metrics
- cover the new guard behaviour with unit tests, including reset and rate-limit scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d71b7f390c832ba739eda4727cdbd9