### PR TITLE
Add architecture and compliance docs and archive setup scripts

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,16 @@
+# Continuous integration
+
+The repository ships with two GitHub Actions workflows:
+
+| Workflow | File | Purpose |
+|----------|------|---------|
+| Default CI | [`ci.yml`](ci.yml) | Runs linting, unit tests, and packaging checks on pull requests and default branch pushes. |
+| Polling trigger smoke test | [`polling_trigger.yml`](polling_trigger.yml) | Exercises the event polling pipeline against fixture data to ensure trigger detection remains stable. |
+
+## Extending the pipelines
+
+1. Update the job matrix to cover new Python versions when dependencies add support.
+2. Pin secret names or environment variables through repository settings rather than hard-coding credentials.
+3. Mirror any new observability or compliance checks described in [`docs/architecture.md`](../../docs/architecture.md) and [`docs/compliance.md`](../../docs/compliance.md) so automated gates stay aligned with runtime expectations.
+
+Refer back to [`README.md`](../../README.md#system-architecture) for the architectural context that CI validates.

--- a/ARCHIVE/Readme.md
+++ b/ARCHIVE/Readme.md
@@ -4,7 +4,7 @@ This folder contains legacy, deprecated, or superseded scripts and files that ar
 
 ## Purpose
 
-- **Preservation:** Important code and logic that may be useful for reference, audits, or future inspiration are kept here rather than being deleted.
+- **Preservation:** Important code and logic that may be useful for reference, audits, or future inspiration are kept here rather than being deleted. Recent additions include the retired bootstrap scripts moved from the repository root (`init_repo_structure.py`, `startup_check.py`) into [`scripts/`](scripts/).
 - **Clarity:** Keeps the main project directory clean, focused only on actively maintained and relevant code.
 - **Transparency:** New contributors can understand the evolution of the codebase and see which approaches or structures have been replaced.
 

--- a/ARCHIVE/scripts/init_repo_structure.py
+++ b/ARCHIVE/scripts/init_repo_structure.py
@@ -1,3 +1,10 @@
+"""Archived bootstrap script kept for historical reference.
+
+This helper previously created placeholder folders during early repository
+prototyping. The automation platform now checks in real modules, so the
+script is no longer required during setup.
+"""
+
 import os
 
 folders = [

--- a/ARCHIVE/scripts/startup_check.py
+++ b/ARCHIVE/scripts/startup_check.py
@@ -1,3 +1,9 @@
+"""Archived environment validation script retained for reference.
+
+Modern deployments rely on standard dependency management and CI checks, so
+this standalone bootstrap verification is no longer invoked by the runtime.
+"""
+
 import os
 import sys
 from dotenv import load_dotenv

--- a/agents/README.md
+++ b/agents/README.md
@@ -3,7 +3,8 @@
 The `agents` package contains the autonomous building blocks that power the event
 processing workflow. Each agent focuses on a narrow responsibility so they can be reused
 or replaced independently when integrating the automation platform into different
-environments.
+environments. For a visual overview of how these agents collaborate, refer to
+[`docs/architecture.md`](../docs/architecture.md).
 
 ## Available agents
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,109 @@
+# Architecture overview
+
+The Agentic Intelligence platform is organised around modular agents that collaborate
+through a lightweight orchestrator. Each agent owns a focused responsibility, making it
+straightforward to replace or extend individual capabilities without rewriting the entire
+pipeline.
+
+## High-level component map
+
+```mermaid
+flowchart LR
+    subgraph Sources
+        Calendar[Google Calendar]
+        Contacts[Google Contacts]
+        Inbox[Shared Mailboxes]
+    end
+
+    subgraph Orchestration
+        Polling[Polling Agent]
+        Trigger[Trigger Detection]
+        Extraction[Extraction Agent]
+        Human[Human-in-the-loop]
+        CRM[CRM Agent]
+        LLM[LLM Strategy]
+        Research[Research Agent]
+        Alerting[Alerting Agent]
+    end
+
+    Calendar --> Polling
+    Contacts --> Polling
+    Polling --> Trigger
+    Trigger --> Extraction
+    Extraction --> Human
+    Human --> CRM
+    Extraction --> CRM
+    CRM --> Downstream[(CRM / Data Warehouse)]
+    Extraction --> Research
+    Research --> Human
+    LLM <--> Trigger
+    LLM <--> Extraction
+    Human --> Alerting
+    Alerting --> IncidentTools[(PagerDuty / Slack)]
+```
+
+## Data flow lifecycle
+
+1. **Polling** retrieves candidate events and associated contacts from Google Workspace
+   using the integration adapters.
+2. **Trigger detection** analyses each event with deterministic keyword rules and an LLM
+   scoring layer to decide whether automation should continue.
+3. **Extraction** converts event metadata into structured dossiers, reusing LLM helpers and
+   deterministic parsers. Confidence scores accompany each field.
+4. **Research** (optional) enriches dossiers with public context such as company profiles
+   or industry notes.
+5. **Human-in-the-loop** receives tasks for incomplete dossiers, ensuring compliance
+   policies are honoured before anything is sent downstream.
+6. **CRM dispatch** pushes finalised dossiers into CRM or knowledge systems, recording
+   the workflow `run_id` for auditing.
+7. **Alerting** escalates anomalies (excessive failures, compliance blocks) to operators via
+   Slack or PagerDuty, closing the loop with observability.
+
+The orchestrator stitches these agents together, sharing configuration through the central
+`Settings` object and propagating the `run_id` for observability.
+
+## Deployment topology
+
+```mermaid
+flowchart TB
+    subgraph Runtime
+        Orchestrator[Workflow Orchestrator]
+        Master[Master Workflow Agent]
+    end
+
+    subgraph ExternalServices[External services]
+        LLMProvider[LLM Provider]
+        CRMBackend[CRM Backend]
+        NotificationStack[Notification Stack]
+    end
+
+    subgraph Storage[Persistence]
+        LogStorage[(Log Storage)]
+        AuditTrail[(Audit Trail)]
+    end
+
+    Orchestrator --> Master
+    Master --> LLMProvider
+    Master --> CRMBackend
+    Master --> NotificationStack
+    Master --> LogStorage
+    Master --> AuditTrail
+```
+
+`WorkflowOrchestrator` typically runs as a scheduled container, VM process, or serverless
+job. External dependencies (LLM providers, CRM APIs, notification stacks) are defined via
+configuration to support different deployments.
+
+## Extension guide
+
+| Extension area | Approach | Key files |
+| -------------- | -------- | --------- |
+| New polling source | Implement `BasePollingAgent` in `agents/interfaces` and register it via `agents/factory.py`. | [`agents/event_polling_agent.py`](../agents/event_polling_agent.py) |
+| Alternative trigger logic | Provide a new `BaseTriggerAgent` implementation or augment the LLM prompts in [`templates/prompts`](../templates/prompts). | [`agents/trigger_detection_agent.py`](../agents/trigger_detection_agent.py) |
+| Custom extraction pipeline | Extend `BaseExtractionAgent` and add deterministic or LLM-based enrichment steps. | [`agents/extraction_agent.py`](../agents/extraction_agent.py) |
+| Human review UX | Replace `HumanInLoopAgent` with an integration that posts to your preferred ticketing/chat platform. | [`agents/human_in_loop_agent.py`](../agents/human_in_loop_agent.py) |
+| Downstream destinations | Swap out `LoggingCrmAgent` for a production CRM connector while reusing shared dossier schemas. | [`agents/crm_agent.py`](../agents/crm_agent.py) |
+| Alert policies | Update or replace `AlertingAgent` once added; alerts should emit OpenTelemetry spans and use `utils/notifications`. | [`logs/README.md`](../logs/README.md) |
+
+Refer back to the root [`README.md`](../README.md) for environment bootstrap steps and the
+`docs/compliance.md` guide for guardrails that apply to every extension.

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -1,0 +1,61 @@
+# Compliance and audit controls
+
+The automation workflow must balance operational efficiency with regulatory and customer
+commitments. This guide summarises the mandatory controls that govern how data flows through
+the agents and how teams should extend the platform.
+
+## Data classification and retention
+
+| Data type | Source | Storage location | Retention | Notes |
+| --------- | ------ | ---------------- | --------- | ----- |
+| Calendar events | Google Calendar API | `log_storage/run_history/events` | 30 days by default | PII is masked before persistence. |
+| Workflow metadata | Orchestrator runtime | `log_storage/run_history/workflows` | 90 days | Includes run IDs, agent decisions, latency metrics. |
+| Human review transcripts | Human-in-the-loop agent | Configurable (`LOG_STORAGE_DIR` or remote queue) | 90 days | Masked when `COMPLIANCE_MODE=strict`. |
+| CRM payloads | CRM agent dispatch | Downstream CRM / data warehouse | Per downstream policy | Attach `run_id` and masking hints. |
+
+Retention values can be adjusted through configuration; shorten them for jurisdictions with
+stricter privacy requirements.
+
+## PII masking and redaction
+
+1. Always call `utils.pii.mask_pii` on any event payload before logging or forwarding to
+   human reviewers.
+2. Enable strict compliance mode (`COMPLIANCE_MODE=strict`) to force redaction in outbound
+   communications and expand numeric masking.
+3. Extend the `PII_FIELD_WHITELIST` only after documenting the business justification in an
+   architecture decision record or ticket.
+
+## Audit logging
+
+* Every workflow run is tagged with a `run_id` that propagates through structured logs,
+  OpenTelemetry spans, CRM payloads, and alert notifications.
+* The `logs` package persists JSON lines files with the masked payload, agent decisions, and
+  timestamps. Do not edit these files manually—rely on the provided log managers.
+* Export telemetry to your observability stack (Grafana, Datadog, Honeycomb) to obtain
+  immutable timelines for investigations.
+
+## Access controls
+
+* Limit credentials loaded through `config.Settings` to service accounts with read-only
+  calendar access and scoped CRM permissions.
+* Store `.env` files and secrets in your secret manager or CI variables instead of committing
+  them to the repository.
+* When running in shared infrastructure, ensure filesystem permissions restrict `log_storage`
+  to the orchestrator user.
+
+## Change management
+
+* New prompts or templates must include metadata describing authorship, change reason, and
+  rollout plan. See [`templates/README.md`](../templates/README.md) for the prompt lifecycle.
+* Feature branches that affect compliance or data handling should link to a risk assessment or
+  legal review ticket in the pull request description.
+* When introducing new agents, update [`docs/architecture.md`](architecture.md) to explain the
+  data flow and specify the controls applied at each stage.
+
+## Incident response
+
+* Configure the Alerting agent to escalate compliance failures (e.g. masking errors,
+  unexpected PII exposure) via PagerDuty or Slack.
+* Use the stored `run_id` to correlate filesystem logs with telemetry when triaging incidents.
+* After remediation, document the root cause and mitigation steps in the incident knowledge
+  base before closing the alert.

--- a/templates/README.md
+++ b/templates/README.md
@@ -2,7 +2,8 @@
 
 Communication templates centralise the wording used by agents when contacting organisers,
 stakeholders, or administrators.  Keeping templates in a dedicated package makes it easy to
-update messaging without touching the automation logic.
+update messaging without touching the automation logic. When adjusting messaging, review the
+masking and approval requirements documented in [`docs/compliance.md`](../docs/compliance.md).
 
 ## Contents
 


### PR DESCRIPTION
## Summary
- expand the root README with system architecture diagrams, agent responsibility descriptions, and a configuration cheat sheet
- add dedicated architecture and compliance documentation, plus CI workflow guidance, while updating cross-links in agent and template docs
- archive the legacy setup scripts under ARCHIVE/scripts with context so the repository root stays clean

## Testing
- not run (docs-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d71f704350832bb279b8e74438ef87